### PR TITLE
Adds internationalization

### DIFF
--- a/code/name/antonsmirnov/javafx/dialog/Dialog.java
+++ b/code/name/antonsmirnov/javafx/dialog/Dialog.java
@@ -4,6 +4,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ResourceBundle;
+
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
@@ -78,8 +80,10 @@ public class Dialog extends Stage {
         protected static final String ICON_PATH = "/name/antonsmirnov/javafx/dialog/";
         
         protected Dialog stage;
-        
-        public Builder create() {
+        private ResourceBundle resources;
+
+      public Builder create() {
+            resources = ResourceBundle.getBundle("dialog");
             stage = new Dialog();
             stage.setResizable(false);
             stage.initStyle(StageStyle.UTILITY);
@@ -146,16 +150,9 @@ public class Dialog extends Stage {
         }
         
         private void alignScrollPane() {
-            stage.setWidth(
-                stage.icon.getImage().getWidth()
-                + Math.max(
-                    stage.messageLabel.getWidth(),
-                    (stage.stacktraceVisible 
-                        ? Math.max(
-                            stage.stacktraceButtonsPanel.getWidth(),
-                            stage.stackTraceLabel.getWidth())
-                        : stage.stacktraceButtonsPanel.getWidth()))
-                + 5 * MARGIN);
+            stage.setWidth(stage.icon.getImage().getWidth() + Math.max(stage.messageLabel.getWidth(),
+                    (stage.stacktraceVisible ? Math.max(stage.stacktraceButtonsPanel.getWidth(),
+                            stage.stackTraceLabel.getWidth()) : stage.stacktraceButtonsPanel.getWidth())) + 5 * MARGIN);
             
             stage.setHeight(
                     Math.max(
@@ -184,10 +181,10 @@ public class Dialog extends Stage {
         // NOTE: invoke once during Dialog creating
         private Builder setStackTrace(Throwable t) {
             // view button
-            stage.viewStacktraceButton = new ToggleButton("View stacktrace");
+            stage.viewStacktraceButton = new ToggleButton(getString("buttonlabel.viewstacktrace"));
             
             // copy button
-            stage.copyStacktraceButton = new Button("Copy to clipboard");
+            stage.copyStacktraceButton = new Button(getString("buttonlabel.copystacktrace"));
             HBox.setMargin(stage.copyStacktraceButton, new Insets(0, 0, 0, MARGIN));
             
             stage.stacktraceButtonsPanel = new HBox();
@@ -294,7 +291,7 @@ public class Dialog extends Stage {
         }
                 
         protected Builder addOkButton() {
-            stage.okButton = new Button("OK");
+            stage.okButton = new Button(getString("buttonlabel.ok"));
             stage.okButton.setPrefWidth(BUTTON_WIDTH);
             stage.okButton.setOnAction(new EventHandler<ActionEvent> () {
 
@@ -330,7 +327,7 @@ public class Dialog extends Stage {
          * @return 
          */
         public Builder addYesButton(EventHandler actionHandler) {
-            return addConfirmationButton("Yes", actionHandler);
+            return addConfirmationButton(getString("buttonlabel.yes"), actionHandler);
         }
         
         /**
@@ -340,7 +337,7 @@ public class Dialog extends Stage {
          * @return 
          */
         public Builder addNoButton(EventHandler actionHandler) {
-            return addConfirmationButton("No", actionHandler);
+            return addConfirmationButton(getString("buttonlabel.no"), actionHandler);
         }
         
         /**
@@ -350,7 +347,7 @@ public class Dialog extends Stage {
          * @return 
          */
         public Builder addCancelButton(EventHandler actionHandler) {
-            return addConfirmationButton("Cancel", actionHandler);
+            return addConfirmationButton(getString("buttonlabel.cancel"), actionHandler);
         }
         
         /**
@@ -366,6 +363,10 @@ public class Dialog extends Stage {
             return stage;
         }
         
+      
+        private String getString(String key) {
+          return resources.getString(key);
+        }
     }
     
     /**

--- a/resources/dialog.properties
+++ b/resources/dialog.properties
@@ -1,0 +1,6 @@
+buttonlabel.ok = OK
+buttonlabel.yes = Yes
+buttonlabel.no = No
+buttonlabel.cancel = Cancel
+buttonlabel.viewstacktrace = View stacktrace
+buttonlabel.copystacktrace = Copy to clipboard

--- a/resources/dialog_fr.properties
+++ b/resources/dialog_fr.properties
@@ -1,0 +1,6 @@
+buttonlabel.ok=OK
+buttonlabel.yes=Oui
+buttonlabel.no=Non
+buttonlabel.cancel=Annuler\
+buttonlabel.viewstacktrace=Consulter l'erreur (stacktrace)
+buttonlabel.copystacktrace=Copier le message d'erreur

--- a/test/name/antonsmirnov/javafx/dialog/LocaleDemo.java
+++ b/test/name/antonsmirnov/javafx/dialog/LocaleDemo.java
@@ -1,0 +1,25 @@
+package name.antonsmirnov.javafx.dialog;
+
+import javafx.application.Application;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.stage.Stage;
+
+import java.util.Locale;
+
+public class LocaleDemo extends Application {
+  public static void main(String[] args) {
+    launch(args);
+  }
+
+  @Override
+  public void start(Stage stage) throws Exception {
+    Locale.setDefault(Locale.FRENCH);
+    Dialog.buildConfirmation("", "").addYesButton(new EventHandler() {
+      @Override
+      public void handle(Event event) {
+        //nothing to do
+      }
+    }).build().show();
+  }
+}


### PR DESCRIPTION
As promised in #4, I have added the option to internationalize the dialog through Java's `ResourceBundle` framework:
The `Builder` now loads texts from Resource Bundle "dialog".
This pull request includes text for English and French, the latter taken from @xaviermichel 's fork.

It also includes a small demo to prove things actually work.
